### PR TITLE
Fixed fillIfEmpty

### DIFF
--- a/src/main/java/me/lorenzo/guimanager/content/InventoryContents.java
+++ b/src/main/java/me/lorenzo/guimanager/content/InventoryContents.java
@@ -178,7 +178,7 @@ public interface InventoryContents {
         public InventoryContents fillIfEmpty(ClickableItem item) {
             for(int row = 0; row < contents.length; row++)
                 for(int column = 0; column < contents[row].length; column++)
-                    if(get(row, column).isPresent()) {
+                    if(!get(row, column).isPresent()) {
                         set(row, column, item);
                     }
 


### PR DESCRIPTION
fillIfEmpty funzionava il contrario, settava solamente se get(row, column).isPresent() era true, e non false